### PR TITLE
bugfixes for Geomash::TGN

### DIFF
--- a/lib/geomash/tgn.rb
+++ b/lib/geomash/tgn.rb
@@ -114,7 +114,9 @@ WHERE
       tgn_term ||= tgn_main_term_info[:label_alt]
       tgn_term ||= tgn_main_term_info[:label_remaining]
 
-      tgn_term_type = tgn_main_term_info[:aat_place].split('/').last
+      tgn_term_type = if tgn_main_term_info[:aat_place]
+                        tgn_main_term_info[:aat_place].split('/').last
+                      end
 
       #Initial Term
       if tgn_term.present? && tgn_term_type.present?
@@ -277,7 +279,7 @@ WHERE
       }
 
                 query = query.squish
-                aat_type_response = Typhoeus::Request.post(self.blazegraph_config[0], :body=>{:query=>query}, :timeout=>500, headers: { Accept: "application/sparql-results+json" })
+                default_label_response = Typhoeus::Request.post(self.blazegraph_config[0], :body=>{:query=>query}, :timeout=>500, headers: { Accept: "application/sparql-results+json" })
               else
                 default_label_response = Typhoeus::Request.get("http://vocab.getty.edu/download/json", :params=>{:uri=>"http://vocab.getty.edu/tgn/#{aat_response['identifier_place']['value']}.json"}, :timeout=>500)
               end

--- a/test/tgn_test.rb
+++ b/test/tgn_test.rb
@@ -49,6 +49,8 @@ class TGNTest < ActiveSupport::TestCase
        assert_equal 'Canaveral, Cape', result[:non_hier_geo][:value]
        assert_nil result[:non_hier_geo][:qualifier]
 
+       result = Geomash::TGN.get_tgn_data('invalid_identifier')
+       assert_nil result
 
     end
   end


### PR DESCRIPTION
fix variable assignment; return nil for invalid TGN IDs (instead of throwing error)