### PR TITLE
fix cases where broader terms do not have skos:prefLabel

### DIFF
--- a/lib/geomash/tgn.rb
+++ b/lib/geomash/tgn.rb
@@ -293,11 +293,13 @@ WHERE
                     else
                       tgn_term ||= ntriple['Object']['value']
                     end
+                  when 'http://www.w3.org/2000/01/rdf-schema#label'
+                    tgn_term ||= ntriple['Object']['value']
                 end
               end
 
               if tgn_term.blank?
-                raise "Could not find a label for broader: #{place_uri} of base term: #{tgn_id}"
+                raise "Could not find a label for broader term: #{aat_response['identifier_place']['value']} of base term: #{tgn_id}"
               end
 
             end


### PR DESCRIPTION
This is a minor change to deal with cases where TGN does not include a `skos:prefLabel` for the term (which should be very infrequently, but it happened with http://vocab.getty.edu/tgn/7026519.) In these cases, use the `rdfs:label` to get the label value.

Also fixes an issue where an unassigned variable was being used in an error message.