### PR TITLE
Fix blank aat term type and sparql 414 errors

### DIFF
--- a/lib/geomash/version.rb
+++ b/lib/geomash/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Geomash
-  VERSION = '0.5.7'
+  VERSION = '0.5.9'
 end

--- a/test/tgn_test.rb
+++ b/test/tgn_test.rb
@@ -59,6 +59,27 @@ class TGNTest < ActiveSupport::TestCase
        assert_equal 'Central', result[:hier_geo][:region]
        assert_nil result[:non_hier_geo]
 
+       result = Geomash::TGN.get_tgn_data('8728596')
+       assert_equal '14.26667', result[:coords][:latitude]
+       assert_equal '170.65', result[:coords][:longitude]
+       assert_equal '14.26667,170.65', result[:coords][:combined]
+       assert_equal 'Eastern District', result[:hier_geo][:area]
+       assert_equal 'American Samoa', result[:hier_geo][:territory]
+       assert_equal 'Oceania', result[:hier_geo][:continent]
+       assert_nil result[:non_hier_geo]
+
+       result = Geomash::TGN.get_tgn_data('7016024')
+       assert_equal '53.8667', result[:coords][:latitude]
+       assert_equal '-166.5333', result[:coords][:longitude]
+       assert_equal '53.8667,-166.5333', result[:coords][:combined]
+       assert_equal 'Unalaska', result[:hier_geo][:city]
+       assert_equal 'Fox Islands', result[:hier_geo][:area]
+       assert_equal 'Unalaska Island', result[:hier_geo][:island]
+       assert_equal 'Alaska', result[:hier_geo][:state]
+       assert_equal 'North and Central America', result[:hier_geo][:continent]
+       assert_equal 'United States', result[:hier_geo][:country]
+       assert_nil result[:non_hier_geo]
+
        result = Geomash::TGN.get_tgn_data('invalid_identifier')
        assert_nil result
     end


### PR DESCRIPTION
- Fallback to `#placeTypeNonPreferred` if `#placeTypePreferred` is not present in initial `tgn` data

- Added '300387064' `case/when`, when setting `hier_geo => area`.

- Changed `broader_place_type_list` `sparql` query to use `POST` instead of `GET` to prevent 414 status code

- Raise error if `tgn_term_type` is absent from initial `tgn` data

- Bumped version